### PR TITLE
Correct the services.yml definition wrapping lines with @ in quotes

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,24 +1,24 @@
 services:
     nomaya.socialBarHelper:
         class : Nomaya\SocialBundle\Helpers\SocialBarHelper
-        tags : 
+        tags :
             - {name : 'templating.helper', alias : 'social-buttons'}
-        arguments : [ @templating ]
+        arguments : [ "@templating" ]
 
     twig.extension.nomaya_social_bar:
         class: Nomaya\SocialBundle\Twig\Extension\NomayaTwigSocialBar
         tags:
             - { name: 'twig.extension' }
-        arguments : [ @service_container ]
+        arguments : [ "@service_container" ]
 
     nomaya.socialLinksHelper:
         class : Nomaya\SocialBundle\Helpers\SocialLinksHelper
-        tags : 
+        tags :
             - {name : 'templating.helper', alias : 'social-links'}
-        arguments : [ @templating ]
+        arguments : [ "@templating" ]
 
     twig.extension.nomaya_social_links:
         class: Nomaya\SocialBundle\Twig\Extension\NomayaTwigSocialLinks
         tags:
             - { name: 'twig.extension' }
-        arguments : [ @service_container ]
+        arguments : [ "@service_container" ]


### PR DESCRIPTION
When trying to run PHPUnit, it will complain about bad syntax and fail due to:

Symfony\Component\Yaml\Exception\ParseException: The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 6 (near "arguments : [ @templating ]").
